### PR TITLE
feat: add url to session object

### DIFF
--- a/src/session.lisp
+++ b/src/session.lisp
@@ -13,7 +13,8 @@
   payment-intent
   payment-method-types
   payment-status
-  success-url)
+  success-url
+  url)
 
 (define-query create-session (:type session)
   (:post "checkout/sessions")


### PR DESCRIPTION
## Background
This PR adds the `url` field to the session object. The url is [needed](https://docs.stripe.com/api/checkout/sessions/object#checkout_session_object-url) to redirect customers to a checkout.

## Changes
- Add `url` field to checkout session

## Testing
I've tested this locally on my end and verified that it works!
![pic-window-240531-0429-31](https://github.com/atlas-engineer/stripe/assets/22579878/3fee0a9a-1ae2-47ab-9a6a-3ce92b045cd1)
