### PR TITLE
feat: add optional typing to objects

### DIFF
--- a/src/object.lisp
+++ b/src/object.lisp
@@ -6,11 +6,12 @@
                   (lambda (x)
                     (let ((name (u:ensure-list x)))
                       (destructuring-bind (name
-                                           &key (reader name) extra-initargs)
+                                           &key (reader name) (type t) extra-initargs)
                           name
                         `(,(u:symbolicate '#:% name)
                           :reader ,reader
                           :initarg ,(u:make-keyword name)
+                          :type ,type
                           ,@(when extra-initargs
                               `(,@(mapcan
                                    (lambda (x)


### PR DESCRIPTION
## Background
This PR provides optional typing to the `define-object` macro, which adds convenience when working with objects but is not required.

## Changes
- Add typing to `define-object` macro; default to `t`.